### PR TITLE
Arma reforger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ The dependencies needed to get your bot online are stated in the main.py. You ca
 - requests==2.25.1
 - aiohttp==3.9.5
 
+### Servers.json "useSteamID" variable
+This variable is responsible for changing the final embed that is handled in messageHandler.py
+Specifically for games like Arma Reforger, we're unable to get any Steam data from the Battlemetrics ban. This means were unable to use the standard embed format that links their Steam profile, and Steam 64 ID.
+
+Setting this variable to False, will mean you will change the "banned_player_profile" variable in your messageHandler.py file.
+
 ### For any further support or enquires join:
 - [discord.lone.design](https://discord.lone.design/)
 - [discord.platformsync.io](https://discord.platformsync.io/)

--- a/config.py
+++ b/config.py
@@ -5,6 +5,18 @@ command_prefix = '.'
 discord_token = 'Your Discord Bot Token goes here'
 # Find that in https://discord.com/developers/applications
 
+### Player Identifier Type ###
+rust_identifier = "steamid"
+arma_reforger_identifier = "reforgerUUID"
+# More can be found here under the "attributes:type": https://www.battlemetrics.com/developers/documentation#resource-identifier
+
+### Player Avatar ###
+steam_error_avatar = "https://i.gyazo.com/2b4181769d85f5adb53694bf156d665c.png"
+arma_reforger_logo = "https://imgur.com/a/QCt85Mg.png"
+
+### Embed Language ###
+perm_banned = "Never - Perm Banned"
+
 # Put your Battlemetrics token in servers.json!
 
 ### Embed Emojis ###
@@ -13,4 +25,4 @@ battlemetrics_Emoji = '😇'
 expiry_Emoji = '😏'
 
 ## Version
-# 1.2.1
+# 1.2.2

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ discord_token = 'Your Discord Bot Token goes here'
 # Find that in https://discord.com/developers/applications
 
 ### Player Identifier Type ###
-rust_identifier = "steamid"
+rust_identifier = "steamID"
 arma_reforger_identifier = "reforgerUUID"
 # More can be found here under the "attributes:type": https://www.battlemetrics.com/developers/documentation#resource-identifier
 

--- a/main.py
+++ b/main.py
@@ -68,24 +68,30 @@ async def track_bans():
                         else:
                             banObject = {}
                             banObject['playerName'] = (ban['meta']['player'][:150] + ' (truncated)') if len(ban['meta']['player']) > 150 else ban['meta']['player']
+                            
                             for identifier in ban['attributes']['identifiers']:
-                                if identifier['type'] == "steamID":
+                                if identifier['type'] == config.rust_identifier:
                                     banObject['steamID'] = identifier['identifier']
                                     if not (identifier.get('metadata') is None):
                                         banObject['avatar'] = identifier['metadata']['profile']['avatarmedium']
                                     else:
-                                        banObject['avatar'] = "https://i.gyazo.com/2b4181769d85f5adb53694bf156d665c.png"
+                                        banObject['avatar'] = config.steam_error_avatar
+                                elif identifier['type'] == config.arma_reforger_identifier:
+                                    banObject['avatar'] = config.arma_reforger_logo
+
                             banObject['reason'] = (ban['attributes']['reason'][:2000] + ' (truncated)') if len(ban['attributes']['reason']) > 2000 else ban['attributes']['reason']
                             banObject['reason'] = banObject['reason'].replace("{", "⁍").replace("}", "⁍")
                             banObject['reason'] = banObject['reason'].replace("⁍⁍timeLeft⁍⁍", "").replace("⁍⁍duration⁍⁍", "")
+                            
                             if ban['attributes']['expires'] == None:
-                                banObject['banLength'] = "Never - Perm Banned"
+                                banObject['banLength'] = config.perm_banned
                             else:
                                 banLength = time.strptime(
                                     ban['attributes']['expires'], "%Y-%m-%dT%H:%M:%S.%fZ")
                                 banLength = time.mktime(banLength)
                                 banObject['banLength'] = datetime.utcfromtimestamp(
                                     banLength).strftime('%a %b %d %Y')
+
                             banObject['banid'] = ban['id']
                             banObject['playerDataID'] = ban['relationships']['player']['data']['id']
                             note = ban['attributes']['note']

--- a/main.py
+++ b/main.py
@@ -78,7 +78,8 @@ async def track_bans():
                                         banObject['avatar'] = config.steam_error_avatar
                                 elif identifier['type'] == config.arma_reforger_identifier:
                                     banObject['avatar'] = config.arma_reforger_logo
-
+                                    banObject['steamID'] = "You must set your servers.json \"useSteamID\" to false - See Readme.md"
+                            
                             banObject['reason'] = (ban['attributes']['reason'][:2000] + ' (truncated)') if len(ban['attributes']['reason']) > 2000 else ban['attributes']['reason']
                             banObject['reason'] = banObject['reason'].replace("{", "⁍").replace("}", "⁍")
                             banObject['reason'] = banObject['reason'].replace("⁍⁍timeLeft⁍⁍", "").replace("⁍⁍duration⁍⁍", "")

--- a/messageHandler.py
+++ b/messageHandler.py
@@ -33,6 +33,12 @@ def sendEmbed(banObject, serverObject):
             "username": serverObject['embedSettings']['EmbedBotName'],
             "avatar_url": serverObject['embedSettings']['EmbedAvatar']
         }
+        
+        if serverObject['embedSettings']['useSteamID'] == True:
+                banned_player_profile = "[{}](https://steamcommunity.com/profiles/{}) - {}".format(banObject['playerName'], banObject['steamID'], banObject['steamID'])
+        else:
+            banned_player_profile = f"{banObject['playerName']}"
+
         if serverObject['embedSettings']['minifyEmbed'] == True:
             data["embeds"] = [
                 {
@@ -41,14 +47,14 @@ def sendEmbed(banObject, serverObject):
                     "fields": [
                         {
                         "name": config.steam_Emoji + " Banned Player",
-                        "value": "[{}](https://steamcommunity.com/profiles/{}) - {}".format(banObject['playerName'], banObject['steamID'], banObject['steamID'])
+                        "value": banned_player_profile
                         },
                         {
                         "name": "Reason",
                         "value": banObject['reason'],
                         "inline": True
                         },
-                         {
+                        {
                         "name": "\u200b",
                         "value": "\u200b",
                         "inline": True
@@ -73,7 +79,7 @@ def sendEmbed(banObject, serverObject):
                     "fields": [
                         {
                         "name": "Banned Player",
-                        "value": "[{}](https://steamcommunity.com/profiles/{}) - {}".format(banObject['playerName'], banObject['steamID'], banObject['steamID'])
+                        "value": banned_player_profile
                         },
                         {
                         "name": "Expiry",
@@ -104,6 +110,14 @@ def sendStaffEmbed(banObject, serverObject):
             "username": serverObject['embedSettings']['EmbedBotName'],
             "avatar_url": serverObject['embedSettings']['EmbedAvatar']
         }
+        
+        if serverObject['embedSettings']['useSteamID'] == True:
+                banned_player_profile = "[{}](https://steamcommunity.com/profiles/{}) - {}".format(banObject['playerName'], banObject['steamID'], banObject['steamID'])
+                banned_player_simplier_profile = f"{banObject['playerName']} - {banObject['steamID']}"
+        else:
+            banned_player_profile = f"{banObject['playerName']}"
+            banned_player_simplier_profile = f"{banObject['playerName']}"
+        
         data["embeds"] = [
                 {
                     "color":  serverObject['color'],
@@ -114,7 +128,7 @@ def sendStaffEmbed(banObject, serverObject):
                     "fields": [
                         {
                         "name": "Player Information",
-                        "value": "{} - {}\n\u200b".format(banObject['playerName'], banObject['steamID']),
+                        "value": banned_player_simplier_profile,
                         "inline": False
                         },
                         {
@@ -129,7 +143,7 @@ def sendStaffEmbed(banObject, serverObject):
                         },
                         {
                         "name": "Steam Links",
-                        "value": "\n\u200b{} Profile: [{}](https://steamcommunity.com/profiles/{})".format(config.steam_Emoji, banObject['steamID'],banObject['steamID']),
+                        "value": f"\n\u200b{config.steam_Emoji} Profile: {banned_player_profile}",
                         "inline": True
                         },
                         {

--- a/servers.json
+++ b/servers.json
@@ -11,6 +11,7 @@
 		],
 		"embedSettings": {
 			"minifyEmbed": true,
+			"useSteamID": true,
 			"EmbedBotName": "My Rust Server Bans",
 			"EmbedAvatar": "https://imgur.com/WeXGthm.png"
 		},
@@ -28,6 +29,7 @@
 		],
 		"embedSettings": {
 			"minifyEmbed": true,
+			"useSteamID": true,
 			"EmbedBotName": "My Rust Server Bans",
 			"EmbedAvatar": "https://imgur.com/gCPIwr9.png"
 		},


### PR DESCRIPTION
# Added Support for Arma Reforger
## Config Variables
Moved some of the hard coded values into the config for easier editing. 
Also added new variables to support other games, that may not have access to the Steam data
### Player Identifier Type
  - rust_identifier = "steamID"
  - arma_reforger_identifier = "reforgerUUID"
 ### Player Avatar
- steam_error_avatar = "https://i.gyazo.com/2b4181769d85f5adb53694bf156d665c.png"
- arma_reforger_logo = "https://imgur.com/a/QCt85Mg.png"
### Embed Language
- perm_banned = "Never - Perm Banned"
## Main.py
Made the appropriate changes to incorporate the config.py changes
Added an `elif` check to test for an Arma Reforger ban
```py
elif identifier['type'] == config.arma_reforger_identifier:
```
## Servers.json
Added a "useSteamID" boolean to check in messageHander.py
Responsible for changing the style of a few variables on the embeds
## MessageHandler.py
Added the "useSteamID" check and set the `banned_player_profile` appropriately
